### PR TITLE
add optional guest users

### DIFF
--- a/abrechnung/config.py
+++ b/abrechnung/config.py
@@ -107,8 +107,23 @@ CONFIG_SCHEMA = Schema.from_dict(
                         metadata={"description": "max file size for uploads in KB"},
                     ),  # in KB
                     "enable_cors": fields.Bool(required=False, load_default=True),
-                    "enable_registration": fields.Bool(
-                        required=False, load_default=False
+                }
+            )
+        ),
+        "registration": fields.Nested(
+            Schema.from_dict(
+                {
+                    "enabled": fields.Bool(
+                        required=False,
+                        load_default=False,
+                        metadata={"description": "allow anyone to register"},
+                    ),
+                    "allow_guest_users": fields.Bool(
+                        required=False,
+                        load_default=False,
+                        metadata={
+                            "description": "allow guest users to register with a valid group invite"
+                        },
                     ),
                     "valid_email_domains": fields.List(
                         fields.Str(),

--- a/abrechnung/database/revisions/0013_register_with_invite.sql
+++ b/abrechnung/database/revisions/0013_register_with_invite.sql
@@ -1,0 +1,5 @@
+-- revision: c019dd21
+-- requires: 5b333d87
+
+alter table usr add column is_guest_user bool default false not null;
+

--- a/abrechnung/domain/users.py
+++ b/abrechnung/domain/users.py
@@ -19,3 +19,4 @@ class User:
     deleted: bool
     pending: bool
     sessions: list[Session]
+    is_guest_user: bool

--- a/abrechnung/http/accounts.py
+++ b/abrechnung/http/accounts.py
@@ -10,7 +10,7 @@ routes = PrefixedRouteTableDef("/api")
 
 async def _account_response(request, account_id: int) -> web.Response:
     account = await request.app["account_service"].get_account(
-        user_id=request["user"]["user_id"], account_id=account_id
+        user=request["user"], account_id=account_id
     )
 
     serializer = AccountSchema()
@@ -27,7 +27,7 @@ async def _account_response(request, account_id: int) -> web.Response:
 async def list_accounts(request):
     try:
         accounts = await request.app["account_service"].list_accounts(
-            user_id=request["user"]["user_id"],
+            user=request["user"],
             group_id=int(request.match_info["group_id"]),
         )
     except PermissionError:
@@ -60,7 +60,7 @@ async def list_accounts(request):
 async def create_account(request: web.Request):
     data = request["json"]
     account_id = await request.app["account_service"].create_account(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         group_id=int(request.match_info["group_id"]),
         name=data["name"],
         description=data["description"],
@@ -106,7 +106,7 @@ async def update_account(request: web.Request):
     account_id = int(request.match_info["account_id"])
     data = request["json"]
     await request.app["account_service"].update_account(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         account_id=account_id,
         name=data["name"],
         description=data["description"],
@@ -126,7 +126,7 @@ async def update_account(request: web.Request):
 async def delete_account(request: web.Request):
     account_id = int(request.match_info["account_id"])
     await request.app["account_service"].delete_account(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         account_id=account_id,
     )
 

--- a/abrechnung/http/groups.py
+++ b/abrechnung/http/groups.py
@@ -22,9 +22,7 @@ routes = PrefixedRouteTableDef("/api")
 @docs(tags=["groups"], summary="list the current users groups", description="")
 async def list_groups(request):
     try:
-        groups = await request.app["group_service"].list_groups(
-            user_id=request["user"]["user_id"]
-        )
+        groups = await request.app["group_service"].list_groups(user=request["user"])
     except NotFoundError:
         raise web.HTTPForbidden(reason="permission denied")
 
@@ -49,7 +47,7 @@ async def list_groups(request):
 async def create_group(request: Request):
     data = request["json"]
     group_id = await request.app["group_service"].create_group(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         name=data["name"],
         description=data["description"],
         currency_symbol=data["currency_symbol"],
@@ -63,7 +61,7 @@ async def create_group(request: Request):
 @docs(tags=["groups"], summary="fetch group details", description="")
 async def get_group(request: Request):
     group = await request.app["group_service"].get_group(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         group_id=int(request.match_info["group_id"]),
     )
 
@@ -88,7 +86,7 @@ async def get_group(request: Request):
 async def update_group(request: Request):
     data = request["json"]
     await request.app["group_service"].update_group(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         group_id=int(request.match_info["group_id"]),
         name=data["name"],
         description=data["description"],
@@ -103,7 +101,7 @@ async def update_group(request: Request):
 @docs(tags=["groups"], summary="delete a group", description="")
 async def delete_group(request: Request):
     await request.app["group_service"].delete_group(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         group_id=int(request.match_info["group_id"]),
     )
 
@@ -114,7 +112,7 @@ async def delete_group(request: Request):
 @docs(tags=["groups"], summary="leave a group", description="")
 async def leave_group(request: Request):
     await request.app["group_service"].leave_group(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         group_id=int(request.match_info["group_id"]),
     )
 
@@ -125,7 +123,7 @@ async def leave_group(request: Request):
 @docs(tags=["groups"], summary="list all members of a group", description="")
 async def list_members(request: web.Request):
     members = await request.app["group_service"].list_members(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         group_id=int(request.match_info["group_id"]),
     )
 
@@ -138,7 +136,7 @@ async def list_members(request: web.Request):
 @docs(tags=["groups"], summary="fetch the group log", description="")
 async def list_log(request: web.Request):
     logs = await request.app["group_service"].list_log(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         group_id=int(request.match_info["group_id"]),
     )
 
@@ -153,7 +151,7 @@ async def list_log(request: web.Request):
 async def send_group_message(request: web.Request):
     data = request["json"]
     await request.app["group_service"].send_group_message(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         group_id=int(request.match_info["group_id"]),
         message=data["message"],
     )
@@ -174,7 +172,7 @@ async def send_group_message(request: web.Request):
 async def update_member_permissions(request: web.Request):
     data = request["json"]
     await request.app["group_service"].update_member_permissions(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         group_id=int(request.match_info["group_id"]),
         member_id=data["user_id"],
         can_write=data["can_write"],
@@ -188,7 +186,7 @@ async def update_member_permissions(request: web.Request):
 @docs(tags=["groups"], summary="list all invite links of a group", description="")
 async def list_invites(request):
     invites = await request.app["group_service"].list_invites(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         group_id=int(request.match_info["group_id"]),
     )
 
@@ -217,7 +215,7 @@ async def create_invite(request: Request):
         valid_until = valid_until.replace(tzinfo=timezone.utc)
 
     await request.app["group_service"].create_invite(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         group_id=int(request.match_info["group_id"]),
         description=data["description"],
         single_use=data["single_use"],
@@ -232,7 +230,7 @@ async def create_invite(request: Request):
 @docs(tags=["groups"], summary="delete a group invite link", description="")
 async def delete_invite(request: Request):
     await request.app["group_service"].delete_invite(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         group_id=int(request.match_info["group_id"]),
         invite_id=int(request.match_info["invite_id"]),
     )
@@ -265,7 +263,7 @@ async def preview_group(request: Request):
 async def join_group(request: Request):
     data = request["json"]
     await request.app["group_service"].join_group(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         invite_token=data["invite_token"],
     )
 

--- a/abrechnung/http/serializers.py
+++ b/abrechnung/http/serializers.py
@@ -159,6 +159,8 @@ class UserSchema(Schema):
     id = fields.Int()
     username = fields.Str()
     email = fields.Email()
+    is_guest_user = fields.Bool()
+    registered_at = fields.DateTime()
     sessions = fields.List(fields.Nested(SessionSchema))
 
 

--- a/abrechnung/http/transactions.py
+++ b/abrechnung/http/transactions.py
@@ -14,7 +14,7 @@ routes = PrefixedRouteTableDef("/api")
 
 async def _transaction_response(request, transaction_id: int) -> web.Response:
     transaction = await request.app["transaction_service"].get_transaction(
-        user_id=request["user"]["user_id"], transaction_id=transaction_id
+        user=request["user"], transaction_id=transaction_id
     )
 
     serializer = TransactionSchema()
@@ -50,7 +50,7 @@ async def list_transactions(request):
             )
 
     transactions = await request.app["transaction_service"].list_transactions(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         group_id=group_id,
         min_last_changed=min_last_changed,
         additional_transactions=forced_transaction_ids,
@@ -92,7 +92,7 @@ async def create_transaction(request: Request):
     group_id: int = int(request.match_info["group_id"])
 
     transaction_id = await request.app["transaction_service"].create_transaction(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         group_id=group_id,
         description=data["description"],
         type=data["type"],
@@ -117,7 +117,7 @@ async def create_transaction(request: Request):
 )
 async def get_transaction(request: Request):
     transaction = await request.app["transaction_service"].get_transaction(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         transaction_id=int(request.match_info["transaction_id"]),
     )
 
@@ -162,7 +162,7 @@ async def update_transaction(request: Request):
     transaction_id = int(request.match_info["transaction_id"])
 
     await request.app["transaction_service"].update_transaction(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         transaction_id=transaction_id,
         value=data["value"],
         description=data["description"],
@@ -201,7 +201,7 @@ async def update_transaction_positions(request: Request):
     transaction_id = int(request.match_info["transaction_id"])
 
     await request.app["transaction_service"].update_transaction_positions(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         transaction_id=transaction_id,
         positions=data["positions"],
         perform_commit=data["perform_commit"],
@@ -220,7 +220,7 @@ async def update_transaction_positions(request: Request):
 async def commit_transaction(request: Request):
     transaction_id = int(request.match_info["transaction_id"])
     await request.app["transaction_service"].commit_transaction(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         transaction_id=transaction_id,
     )
 
@@ -237,7 +237,7 @@ async def commit_transaction(request: Request):
 async def delete_transaction(request: Request):
     transaction_id = int(request.match_info["transaction_id"])
     await request.app["transaction_service"].delete_transaction(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         transaction_id=transaction_id,
     )
 
@@ -254,7 +254,7 @@ async def delete_transaction(request: Request):
 async def create_transaction_change(request: Request):
     transaction_id = int(request.match_info["transaction_id"])
     await request.app["transaction_service"].create_transaction_change(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         transaction_id=int(request.match_info["transaction_id"]),
     )
 
@@ -271,7 +271,7 @@ async def create_transaction_change(request: Request):
 async def discard_transaction_change(request: Request):
     transaction_id = int(request.match_info["transaction_id"])
     await request.app["transaction_service"].discard_transaction_changes(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         transaction_id=transaction_id,
     )
 
@@ -305,7 +305,7 @@ async def upload_file(request: Request):
         raise web.HTTPBadRequest(reason=f"Cannot read uploaded file: {e}")
 
     await request.app["transaction_service"].upload_file(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         transaction_id=transaction_id,
         filename=filename,
         mime_type=mime_type,
@@ -324,7 +324,7 @@ async def upload_file(request: Request):
 )
 async def delete_file(request: Request):
     transaction_id, revision_id = await request.app["transaction_service"].delete_file(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         file_id=int(request.match_info["file_id"]),
     )
 
@@ -341,7 +341,7 @@ async def get_file_contents(request: Request):
     file_id = int(request.match_info["file_id"])
     blob_id = int(request.match_info["blob_id"])
     mime_type, content = await request.app["transaction_service"].read_file_contents(
-        user_id=request["user"]["user_id"],
+        user=request["user"],
         file_id=file_id,
         blob_id=blob_id,
     )

--- a/config/abrechnung.yaml
+++ b/config/abrechnung.yaml
@@ -14,7 +14,9 @@ api:
   host: "localhost"
   port: 8080
   id: default
-  enable_registration: true
+
+registration:
+  enabled: false
 
 # email:
 #   address: "abrechnung@example.lol"

--- a/tests/http_tests/__init__.py
+++ b/tests/http_tests/__init__.py
@@ -103,13 +103,13 @@ class HTTPAPITest(BaseHTTPAPITest):
     async def setUpAsync(self) -> None:
         await super().setUpAsync()
 
-        self.test_user_id, password = await self._create_test_user(
+        self.test_user, password = await self._create_test_user(
             "user1", "user1@email.stuff"
         )
         _, session_id, _ = await self.user_service.login_user(
             "user1", password=password, session_name="session1"
         )
-        self.jwt_token = token_for_user(self.test_user_id, session_id, self.secret_key)
+        self.jwt_token = token_for_user(self.test_user.id, session_id, self.secret_key)
 
     async def _post(self, *args, **kwargs):
         headers = kwargs.pop("headers", {})

--- a/tests/http_tests/test_transactions.py
+++ b/tests/http_tests/test_transactions.py
@@ -6,7 +6,7 @@ from tests.http_tests import HTTPAPITest
 class TransactionAPITest(HTTPAPITest):
     async def _create_group(self) -> int:
         return await self.group_service.create_group(
-            user_id=self.test_user_id,
+            user=self.test_user,
             name="name",
             description="description",
             currency_symbol="€",
@@ -15,7 +15,7 @@ class TransactionAPITest(HTTPAPITest):
 
     async def _create_account(self, group_id: int, name: str) -> int:
         return await self.account_service.create_account(
-            user_id=self.test_user_id,
+            user=self.test_user,
             group_id=group_id,
             type="personal",
             name=name,
@@ -86,7 +86,7 @@ class TransactionAPITest(HTTPAPITest):
 
     async def test_create_transaction(self):
         group_id = await self.group_service.create_group(
-            user_id=self.test_user_id,
+            user=self.test_user,
             name="name",
             description="description",
             currency_symbol="€",
@@ -109,14 +109,14 @@ class TransactionAPITest(HTTPAPITest):
 
     async def test_list_transactions(self):
         group_id = await self.group_service.create_group(
-            user_id=self.test_user_id,
+            user=self.test_user,
             name="name",
             description="description",
             currency_symbol="€",
             terms="terms",
         )
         transaction1_id = await self.transaction_service.create_transaction(
-            user_id=self.test_user_id,
+            user=self.test_user,
             group_id=group_id,
             type="purchase",
             description="description123",
@@ -126,7 +126,7 @@ class TransactionAPITest(HTTPAPITest):
             value=122.22,
         )
         transaction2_id = await self.transaction_service.create_transaction(
-            user_id=self.test_user_id,
+            user=self.test_user,
             group_id=group_id,
             type="purchase",
             description="description123",
@@ -146,7 +146,7 @@ class TransactionAPITest(HTTPAPITest):
 
         account_id = await self._create_account(group_id=group_id, name="account1")
         transaction3_id = await self.transaction_service.create_transaction(
-            user_id=self.test_user_id,
+            user=self.test_user,
             group_id=group_id,
             type="purchase",
             description="foobar",
@@ -160,7 +160,7 @@ class TransactionAPITest(HTTPAPITest):
 
         # check that the list endpoint without parameters returns all objects
         await self.transaction_service.commit_transaction(
-            user_id=self.test_user_id, transaction_id=transaction3_id
+            user=self.test_user, transaction_id=transaction3_id
         )
         resp = await self._get(f"/api/v1/groups/{group_id}/transactions")
         self.assertEqual(200, resp.status)
@@ -186,7 +186,7 @@ class TransactionAPITest(HTTPAPITest):
     async def test_get_transaction(self):
         group_id = await self._create_group()
         transaction_id = await self.transaction_service.create_transaction(
-            user_id=self.test_user_id,
+            user=self.test_user,
             group_id=group_id,
             type="purchase",
             description="description123",
@@ -208,7 +208,7 @@ class TransactionAPITest(HTTPAPITest):
     async def test_update_transaction(self):
         group_id = await self._create_group()
         transaction_id = await self.transaction_service.create_transaction(
-            user_id=self.test_user_id,
+            user=self.test_user,
             group_id=group_id,
             type="purchase",
             description="description123",
@@ -316,7 +316,7 @@ class TransactionAPITest(HTTPAPITest):
         account1_id = await self._create_account(group_id, "account1")
         account2_id = await self._create_account(group_id, "account2")
         transaction_id = await self.transaction_service.create_transaction(
-            user_id=self.test_user_id,
+            user=self.test_user,
             group_id=group_id,
             type="purchase",
             description="description123",
@@ -411,7 +411,7 @@ class TransactionAPITest(HTTPAPITest):
         group_id = await self._create_group()
         account1_id = await self._create_account(group_id, "account1")
         transaction_id = await self.transaction_service.create_transaction(
-            user_id=self.test_user_id,
+            user=self.test_user,
             group_id=group_id,
             type="purchase",
             description="description123",
@@ -435,14 +435,14 @@ class TransactionAPITest(HTTPAPITest):
     async def test_account_deletion(self):
         group_id = await self._create_group()
         account1_id = await self.account_service.create_account(
-            user_id=self.test_user_id,
+            user=self.test_user,
             group_id=group_id,
             type="personal",
             name="account1",
             description="description",
         )
         transaction_id = await self.transaction_service.create_transaction(
-            user_id=self.test_user_id,
+            user=self.test_user,
             group_id=group_id,
             type="purchase",
             description="description123",
@@ -459,14 +459,14 @@ class TransactionAPITest(HTTPAPITest):
         self.assertEqual(200, resp.status)
 
         account2_id = await self.account_service.create_account(
-            user_id=self.test_user_id,
+            user=self.test_user,
             group_id=group_id,
             type="personal",
             name="account2",
             description="description",
         )
         account3_id = await self.account_service.create_account(
-            user_id=self.test_user_id,
+            user=self.test_user,
             group_id=group_id,
             type="personal",
             name="account3",
@@ -520,21 +520,21 @@ class TransactionAPITest(HTTPAPITest):
     async def test_purchase_items(self):
         group_id = await self._create_group()
         account1_id = await self.account_service.create_account(
-            user_id=self.test_user_id,
+            user=self.test_user,
             group_id=group_id,
             type="personal",
             name="account1",
             description="foobar",
         )
         account2_id = await self.account_service.create_account(
-            user_id=self.test_user_id,
+            user=self.test_user,
             group_id=group_id,
             type="personal",
             name="account2",
             description="foobar",
         )
         transaction_id = await self.transaction_service.create_transaction(
-            user_id=self.test_user_id,
+            user=self.test_user,
             group_id=group_id,
             type="purchase",
             description="description123",

--- a/tests/http_tests/test_websocket.py
+++ b/tests/http_tests/test_websocket.py
@@ -17,14 +17,14 @@ class WebsocketAPITest(BaseHTTPAPITest):
         self.assertEqual(expected_msg, resp_json | expected_msg)
 
     async def test_websocket_notifications(self):
-        user_id, password = await self._create_test_user(
+        user, password = await self._create_test_user(
             username="user", email="email@email.com"
         )
         _, session_id, _ = await self.user_service.login_user(
             "user", password=password, session_name="session1"
         )
         token = token_for_user(
-            user_id, session_id=session_id, secret_key=self.secret_key
+            user.id, session_id=session_id, secret_key=self.secret_key
         )
 
         ws = await self.client.ws_connect("/api/v1/ws")
@@ -34,7 +34,7 @@ class WebsocketAPITest(BaseHTTPAPITest):
             {
                 "type": "subscribe",
                 "token": token,
-                "data": {"subscription_type": "group", "element_id": user_id},
+                "data": {"subscription_type": "group", "element_id": user.id},
             }
         )
 
@@ -43,14 +43,14 @@ class WebsocketAPITest(BaseHTTPAPITest):
             {
                 "type": "subscribe_success",
                 "data": {
-                    "element_id": user_id,
+                    "element_id": user.id,
                     "subscription_type": "group",
                 },
             },
         )
 
         group_id = await self.group_service.create_group(
-            user_id=user_id,
+            user=user,
             name="group1",
             description="asdf",
             currency_symbol="€",
@@ -63,7 +63,7 @@ class WebsocketAPITest(BaseHTTPAPITest):
             {
                 "type": "notification",
                 "data": {
-                    "element_id": user_id,
+                    "element_id": user.id,
                     "group_id": group_id,
                     "subscription_type": "group",
                 },
@@ -90,7 +90,7 @@ class WebsocketAPITest(BaseHTTPAPITest):
         )
 
         account_id = await self.account_service.create_account(
-            user_id=user_id,
+            user=user,
             group_id=group_id,
             type="personal",
             name="group1",
@@ -129,7 +129,7 @@ class WebsocketAPITest(BaseHTTPAPITest):
         )
 
         transaction_id = await self.transaction_service.create_transaction(
-            user_id=user_id,
+            user=user,
             group_id=group_id,
             type="transfer",
             value=1.2,
@@ -175,7 +175,7 @@ class WebsocketAPITest(BaseHTTPAPITest):
         )
 
         invite_id = await self.group_service.create_invite(
-            user_id=user_id,
+            user=user,
             group_id=group_id,
             description="foobar invite",
             single_use=False,
@@ -237,7 +237,7 @@ class WebsocketAPITest(BaseHTTPAPITest):
             {
                 "type": "unsubscribe",
                 "token": token,
-                "data": {"subscription_type": "group", "element_id": user_id},
+                "data": {"subscription_type": "group", "element_id": user.id},
             }
         )
 
@@ -246,7 +246,7 @@ class WebsocketAPITest(BaseHTTPAPITest):
             {
                 "type": "unsubscribe_success",
                 "data": {
-                    "element_id": user_id,
+                    "element_id": user.id,
                     "subscription_type": "group",
                 },
             },

--- a/tests/test_mailer.py
+++ b/tests/test_mailer.py
@@ -82,11 +82,9 @@ class MailerTest(AsyncTestCase):
     async def test_email_change_mail_delivery(self):
         user_email = "user@email.com"
         new_email = "new_email@email.com"
-        user_id, password = await self._create_test_user(
-            username="user", email=user_email
-        )
+        user, password = await self._create_test_user(username="user", email=user_email)
         await self.user_service.request_email_change(
-            user_id=user_id, password=password, email=new_email
+            user=user, password=password, email=new_email
         )
 
         await asyncio.sleep(0.5)

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -150,11 +150,12 @@ export async function logout() {
     removeToken();
 }
 
-export async function register({ username, email, password }) {
+export async function register({ username, email, password, inviteToken }) {
     const resp = await bareApi.post("/auth/register", {
         username: username,
         email: email,
         password: password,
+        invite_token: inviteToken,
     });
     return resp.data;
 }

--- a/web/src/components/accounts/AccountTransactionListEntry.js
+++ b/web/src/components/accounts/AccountTransactionListEntry.js
@@ -1,5 +1,3 @@
-import { useRecoilValue } from "recoil";
-import { accountsSeenByUser } from "../../recoil/accounts";
 import ListItemLink from "../style/ListItemLink";
 import { Chip, ListItemAvatar, ListItemText, Tooltip, Typography } from "@mui/material";
 import { HelpOutline } from "@mui/icons-material";
@@ -9,8 +7,6 @@ import { balanceColor } from "../../utils";
 import { PurchaseIcon, TransferIcon } from "../style/AbrechnungIcons";
 
 export default function AccountTransactionListEntry({ group, transaction, accountID }) {
-    const accounts = useRecoilValue(accountsSeenByUser(group.id));
-
     return (
         <ListItemLink to={`/groups/${group.id}/transactions/${transaction.id}`}>
             <ListItemAvatar sx={{ minWidth: { xs: "40px", md: "56px" } }}>

--- a/web/src/components/style/SidebarGroupList.js
+++ b/web/src/components/style/SidebarGroupList.js
@@ -5,9 +5,11 @@ import ListItemLink from "./ListItemLink";
 import GroupCreateModal from "../groups/GroupCreateModal";
 import React, { useState } from "react";
 import { Add } from "@mui/icons-material";
+import { isGuestUser } from "../../recoil/auth";
 
 export default function SidebarGroupList({ group = null }) {
     const groups = useRecoilValue(groupList);
+    const isGuest = useRecoilValue(isGuestUser);
     const [showGroupCreationModal, setShowGroupCreationModal] = useState(false);
 
     return (
@@ -21,15 +23,19 @@ export default function SidebarGroupList({ group = null }) {
                         <ListItemText primary={it.name} />
                     </ListItemLink>
                 ))}
-                <ListItem sx={{ padding: 0 }}>
-                    <Grid container justifyContent="center">
-                        <IconButton size="small" onClick={() => setShowGroupCreationModal(true)}>
-                            <Add />
-                        </IconButton>
-                    </Grid>
-                </ListItem>
+                {!isGuest && (
+                    <ListItem sx={{ padding: 0 }}>
+                        <Grid container justifyContent="center">
+                            <IconButton size="small" onClick={() => setShowGroupCreationModal(true)}>
+                                <Add />
+                            </IconButton>
+                        </Grid>
+                    </ListItem>
+                )}
             </List>
-            <GroupCreateModal show={showGroupCreationModal} onClose={() => setShowGroupCreationModal(false)} />
+            {!isGuest && (
+                <GroupCreateModal show={showGroupCreationModal} onClose={() => setShowGroupCreationModal(false)} />
+            )}
         </>
     );
 }

--- a/web/src/components/transactions/TransactionListEntry.js
+++ b/web/src/components/transactions/TransactionListEntry.js
@@ -1,11 +1,11 @@
 import ListItemLink from "../style/ListItemLink";
 import { Chip, Divider, ListItemAvatar, ListItemText, Tooltip, Typography } from "@mui/material";
-import { CompareArrows, HelpOutline, ShoppingCart } from "@mui/icons-material";
+import { HelpOutline } from "@mui/icons-material";
 import { DateTime } from "luxon";
 import React from "react";
 import { useRecoilValue } from "recoil";
 import { accountsSeenByUser } from "../../recoil/accounts";
-import { TransferIcon, PurchaseIcon } from "../style/AbrechnungIcons";
+import { PurchaseIcon, TransferIcon } from "../style/AbrechnungIcons";
 
 export function TransactionListEntry({ group, transaction }) {
     const accounts = useRecoilValue(accountsSeenByUser(group.id));

--- a/web/src/pages/auth/Login.js
+++ b/web/src/pages/auth/Login.js
@@ -46,6 +46,8 @@ export default function Login() {
     const history = useHistory();
     const classes = useStyles();
 
+    const queryArgsForward = query.get("next") != null ? "?next=" + query.get("next") : "";
+
     useTitle("Abrechnung - Login");
 
     useEffect(() => {
@@ -136,7 +138,7 @@ export default function Login() {
                             </Button>
                             <Grid container justify="flex-end">
                                 <Grid item>
-                                    <Link to="/register" component={RouterLink} variant="body2">
+                                    <Link to={`/register${queryArgsForward}`} component={RouterLink} variant="body2">
                                         No account? register
                                     </Link>
                                 </Grid>

--- a/web/src/pages/groups/GroupInvites.js
+++ b/web/src/pages/groups/GroupInvites.js
@@ -6,16 +6,28 @@ import { deleteGroupInvite } from "../../api";
 import { currUserPermissions, groupInvites, groupMembers } from "../../recoil/groups";
 import { useRecoilValue } from "recoil";
 import { DateTime } from "luxon";
-import { Grid, IconButton, List, ListItem, ListItemSecondaryAction, ListItemText, Typography } from "@mui/material";
+import {
+    Alert,
+    Grid,
+    IconButton,
+    List,
+    ListItem,
+    ListItemSecondaryAction,
+    ListItemText,
+    Typography,
+} from "@mui/material";
 import { Add, ContentCopy, Delete } from "@mui/icons-material";
 import { MobilePaper } from "../../components/style/mobile";
 import { useTitle } from "../../utils";
+import { isGuestUser } from "../../recoil/auth";
 
 export default function GroupInvites({ group }) {
     const [showModal, setShowModal] = useState(false);
     const invites = useRecoilValue(groupInvites(group.id));
     const members = useRecoilValue(groupMembers(group.id));
     const userPermissions = useRecoilValue(currUserPermissions(group.id));
+
+    const isGuest = useRecoilValue(isGuestUser);
 
     useTitle(`${group.name} - Invite Links`);
 
@@ -58,6 +70,11 @@ export default function GroupInvites({ group }) {
             <Typography component="h3" variant="h5">
                 Active Invite Links
             </Typography>
+            {isGuest && (
+                <Alert severity="info">
+                    You are a guest user on this Abrechnung and therefore not permitted to create group invites.
+                </Alert>
+            )}
             <List>
                 {invites.length === 0 ? (
                     <ListItem>
@@ -105,7 +122,7 @@ export default function GroupInvites({ group }) {
                     ))
                 )}
             </List>
-            {userPermissions.can_write && (
+            {userPermissions.can_write && !isGuestUser && (
                 <>
                     <Grid container justifyContent="center">
                         <IconButton color="primary" onClick={() => setShowModal(true)}>

--- a/web/src/pages/groups/GroupList.js
+++ b/web/src/pages/groups/GroupList.js
@@ -4,15 +4,26 @@ import { groupList } from "../../recoil/groups";
 import ListItemLink from "../../components/style/ListItemLink";
 import GroupCreateModal from "../../components/groups/GroupCreateModal";
 import GroupDeleteModal from "../../components/groups/GroupDeleteModal";
-import { Grid, IconButton, List, ListItem, ListItemSecondaryAction, ListItemText, Typography } from "@mui/material";
+import {
+    Alert,
+    Grid,
+    IconButton,
+    List,
+    ListItem,
+    ListItemSecondaryAction,
+    ListItemText,
+    Typography,
+} from "@mui/material";
 import { Add, Delete } from "@mui/icons-material";
 import { MobilePaper } from "../../components/style/mobile";
+import { isGuestUser } from "../../recoil/auth";
 
 export default function GroupList() {
     const [showGroupCreationModal, setShowGroupCreationModal] = useState(false);
     const [showGroupDeletionModal, setShowGroupDeletionModal] = useState(false);
     const [groupToDelete, setGroupToDelete] = useState(null);
     const groups = useRecoilValue(groupList);
+    const isGuest = useRecoilValue(isGuestUser);
 
     const openGroupDeletionModal = (groupID) => {
         setGroupToDelete(groups.find((group) => group.id === groupID));
@@ -29,6 +40,11 @@ export default function GroupList() {
             <Typography component="h3" variant="h5">
                 Groups
             </Typography>
+            {isGuest && (
+                <Alert severity="info">
+                    You are a guest user on this Abrechnung and therefore not permitted to create new groups.
+                </Alert>
+            )}
             <List>
                 {groups.length === 0 ? (
                     <ListItem key={0}>
@@ -55,12 +71,16 @@ export default function GroupList() {
                     })
                 )}
             </List>
-            <Grid container justifyContent="center">
-                <IconButton color="primary" onClick={() => setShowGroupCreationModal(true)}>
-                    <Add />
-                </IconButton>
-            </Grid>
-            <GroupCreateModal show={showGroupCreationModal} onClose={() => setShowGroupCreationModal(false)} />
+            {!isGuest && (
+                <>
+                    <Grid container justifyContent="center">
+                        <IconButton color="primary" onClick={() => setShowGroupCreationModal(true)}>
+                            <Add />
+                        </IconButton>
+                    </Grid>
+                    <GroupCreateModal show={showGroupCreationModal} onClose={() => setShowGroupCreationModal(false)} />
+                </>
+            )}
             <GroupDeleteModal
                 show={showGroupDeletionModal}
                 onClose={closeGroupDeletionModal}

--- a/web/src/pages/profile/Profile.js
+++ b/web/src/pages/profile/Profile.js
@@ -1,12 +1,14 @@
 import React from "react";
 import { useRecoilValue } from "recoil";
-import { userData } from "../../recoil/auth";
-import { List, ListItem, ListItemText, Typography } from "@mui/material";
+import { isGuestUser, userData } from "../../recoil/auth";
+import { Alert, List, ListItem, ListItemText, Typography } from "@mui/material";
 import { MobilePaper } from "../../components/style/mobile";
 import { useTitle } from "../../utils";
+import { DateTime } from "luxon";
 
 export default function Profile() {
     const user = useRecoilValue(userData);
+    const isGuest = useRecoilValue(isGuestUser);
     useTitle("Abrechnung - Profile");
 
     return (
@@ -14,6 +16,12 @@ export default function Profile() {
             <Typography component="h3" variant="h5">
                 Profile
             </Typography>
+            {isGuest && (
+                <Alert severity="info">
+                    You are a guest user on this Abrechnung and therefore not permitted to create new groups or group
+                    invites.
+                </Alert>
+            )}
             <List>
                 <ListItem>
                     <ListItemText primary="Username" secondary={user.username} />
@@ -22,7 +30,10 @@ export default function Profile() {
                     <ListItemText primary="E-Mail" secondary={user.email} />
                 </ListItem>
                 <ListItem>
-                    <ListItemText primary="Registered" secondary={user.registered_at} />
+                    <ListItemText
+                        primary="Registered"
+                        secondary={DateTime.fromISO(user.registered_at).toLocaleString(DateTime.DATETIME_FULL)}
+                    />
                 </ListItem>
             </List>
         </MobilePaper>

--- a/web/src/recoil/auth.js
+++ b/web/src/recoil/auth.js
@@ -35,6 +35,14 @@ export const userData = atom({
     ],
 });
 
+export const isGuestUser = selector({
+    key: "isGuestUser",
+    get: async ({ get }) => {
+        const user = get(userData);
+        return user.is_guest_user;
+    },
+});
+
 export const isAuthenticated = selector({
     key: "isAuthenticated",
     get: async ({ get }) => {


### PR DESCRIPTION
Add a config option that enables guest users when registration is disabled or constrained.

User can register with a valid invite link to a group and become guest users on an instance. Guest users are only allowed to participate in groups they are invited to. They are not allowed to create new groups or add invites to existing groups.