### PR TITLE
Fix #108 - Allow locale sensitive decimal in transfer/purchase modal

### DIFF
--- a/web/src/components/transactions/purchase/PurchaseCreateModal.tsx
+++ b/web/src/components/transactions/purchase/PurchaseCreateModal.tsx
@@ -102,6 +102,7 @@ export default function PurchaseCreateModal({ group, show, onClose }) {
                                 required
                                 fullWidth
                                 type="number"
+                                inputProps={{"step": "any"}} 
                                 variant="standard"
                                 name="value"
                                 label="Value"

--- a/web/src/components/transactions/transfer/TransferCreateModal.tsx
+++ b/web/src/components/transactions/transfer/TransferCreateModal.tsx
@@ -108,6 +108,7 @@ export default function TransferCreateModal({ group, show, onClose }) {
                                 required
                                 fullWidth
                                 type="number"
+                                inputProps={{"step": "any"}} 
                                 variant="standard"
                                 name="value"
                                 label="Value"


### PR DESCRIPTION
This will fix the numeric input for Safari  in the transfer/purchase modal for the currently set locale.
So if you have an US format with dot it will allow . values but not comma values. Which should be ok.
In case we don't want this to happen we probably need to get rid of the type numeric which would have a few downsides.

Also stumbled upon TransactionCreateModal.tsx which would have the same problem, but isn't used anywhere in the codebase? That should probably be removed 