### PR TITLE
Add group currency symbol to purchase/transfer

### DIFF
--- a/web/src/components/transactions/purchase/PurchaseCreateModal.tsx
+++ b/web/src/components/transactions/purchase/PurchaseCreateModal.tsx
@@ -27,7 +27,7 @@ export default function PurchaseCreateModal({ group, show, onClose }) {
             description: values.description,
             value: parseFloat(values.value),
             billedAt: values.billedAt.toISODate(),
-            currencySymbol: "€",
+            currencySymbol: group.currency_symbol,
             currencyConversionRate: 1.0,
             creditorShares: { [values.creditor.id]: 1.0 },
         })

--- a/web/src/components/transactions/transfer/TransferCreateModal.tsx
+++ b/web/src/components/transactions/transfer/TransferCreateModal.tsx
@@ -28,7 +28,7 @@ export default function TransferCreateModal({ group, show, onClose }) {
             description: values.description,
             value: parseFloat(values.value),
             billedAt: values.billedAt.toISODate(),
-            currencySymbol: "€",
+            currencySymbol: group.currency_symbol,
             currencyConversionRate: 1.0,
             creditorShares: { [values.creditor.id]: 1.0 },
             debitorShares: { [values.debitor.id]: 1.0 },


### PR DESCRIPTION
Add configured group currency symbol to purchases and transfers

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/6337990/174349121-23f44403-db41-4b39-824e-0b57a892ec21.png">

<img width="1142" alt="image" src="https://user-images.githubusercontent.com/6337990/174349187-6c02bff2-74ab-4b08-a1aa-560094bb97ac.png">
