### PR TITLE
fix yarn build

### DIFF
--- a/web/src/components/accounts/Balances.tsx
+++ b/web/src/components/accounts/Balances.tsx
@@ -150,7 +150,7 @@ export default function Balances({ group }) {
                                         width={yaxiswidth}
                                     />
                                     <Tooltip
-                                        formatter={(label) =>
+                                        formatter={(label: string) =>
                                             parseFloat(label).toFixed(2) + ` ${group.currency_symbol}`
                                         }
                                         labelStyle={{


### PR DESCRIPTION
This fixes the following error during yarn build:
```
TS2345: Argument of type 'ValueType' is not assignable to parameter of type 'string'.
  Type 'number' is not assignable to type 'string'.
    152 |                                     <Tooltip
    153 |                                         formatter={(label) =>
  > 154 |                                             parseFloat(label).toFixed(2) + ` ${group.currency_symbol}`
        |                                                        ^^^^^
    155 |                                         }
    156 |                                         labelStyle={{
    157 |                                             color: theme.palette.text.primary,
```