### PR TITLE
Add a Helm Chart

### DIFF
--- a/charts/abrechnung/.helmignore
+++ b/charts/abrechnung/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/abrechnung/Chart.yaml
+++ b/charts/abrechnung/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: abrechnung
+description: A Helm chart for abrechnung
+type: application
+version: 0.1.0
+appVersion: "v0.11.0"
+keywords:
+- docker
+- registry
+- harbor
+home: https://github.com/SFTtech/abrechnung
+sources:
+- https://github.com/SFTtech/abrechnung

--- a/charts/abrechnung/README.md
+++ b/charts/abrechnung/README.md
@@ -1,0 +1,9 @@
+# Abrechnung Helm Chart
+
+## Development
+
+Template the chart: In the Chart directory run:
+`helm template . -f values.yaml`
+
+Install the chart to your default cluster:
+`helm upgrade --create-namespace --namespace abrechnung --install abrechnung . -f values.yaml --debug`

--- a/charts/abrechnung/templates/NOTES.txt
+++ b/charts/abrechnung/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "abrechnung.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "abrechnung.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "abrechnung.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "abrechnung.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/abrechnung/templates/_helpers.tpl
+++ b/charts/abrechnung/templates/_helpers.tpl
@@ -1,0 +1,121 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "abrechnung.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "abrechnung.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "abrechnung.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "abrechnung.labels" -}}
+helm.sh/chart: {{ include "abrechnung.chart" . }}
+{{ include "abrechnung.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "abrechnung.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "abrechnung.name" . }}-frontend
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "abrechnung.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "abrechnung.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+
+{{/* Generate env */}}
+{{- define "abrechnung.env" -}}
+- name: SERVICE_URL
+  value: {{ .Values.abrechnung.url }}
+- name: SERVICE_API_URL
+  value: "{{ .Values.abrechnung.url }}/api"
+- name: SERVICE_NAME
+  value: {{ .Values.abrechnung.name }}
+- name: DB_HOST
+  value: {{ .Values.postgresql.host }}
+- name: DB_USER
+  value: {{ .Values.postgresql.user }}
+- name: DB_NAME
+  value: {{ .Values.postgresql.name }}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.postgresql.existingSecretName }}
+      key: {{ .Values.postgresql.existingSecretKey }}
+- name: ABRECHNUNG_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.abrechnung.pythonSecret.existingSecretName }}
+      key: {{ .Values.abrechnung.pythonSecret.existingSecretKey }}
+- name: ABRECHNUNG_PORT
+  value: "{{ .Values.abrechnung.port }}"
+- name: ABRECHNUNG_ID
+  value: {{ .Values.abrechnung.id }}
+- name: REGISTRATION_ENABLED
+  value: "{{ .Values.abrechnung.registration.enabled }}"
+- name: REGISTRATION_VALID_EMAIL_DOMAINS
+  value: {{ .Values.abrechnung.registration.validEmailDomains }}
+- name: REGISTRATION_ALLOW_GUEST_USERS
+  value: "{{ .Values.abrechnung.registration.allowGuestUsers }}"
+- name: ABRECHNUNG_EMAIL
+  value: {{ .Values.abrechnung.email.address }}
+- name: SMTP_HOST
+  value: {{ .Values.abrechnung.email.host }}
+- name: SMTP_PORT
+  value: "{{ .Values.abrechnung.email.port }}"
+- name: SMTP_MODE
+  value: {{ .Values.abrechnung.email.mode }}
+- name: SMTP_USER
+  value: {{ .Values.abrechnung.email.username }}
+- name: SMTP_PASSWORD
+  value: "replaceme"
+  value: {{ .Values.abrechnung.email.password }}
+- name: POSTGRES_USER
+  value: {{ .Values.postgresql.user }}
+- name: POSTGRES_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.postgresql.existingSecretName }}
+      key: {{ .Values.postgresql.existingSecretKey }}
+- name: POSTGRES_DATABASE
+  value: {{ .Values.postgresql.name }}
+{{- end }}

--- a/charts/abrechnung/templates/configmap.yaml
+++ b/charts/abrechnung/templates/configmap.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "abrechnung.fullname" . }}-nginx-config
+  labels:
+    {{- include "abrechnung.labels" . | nindent 4 }}
+data:
+  nginx.conf: |
+    upstream abrechnung_api {
+        server localhost:8080;
+    }
+
+    server {
+        listen 80;
+        listen [::]:80;
+
+        server_name _;
+
+        charset utf-8;
+
+        access_log /dev/stdout;
+        error_log /dev/stderr;
+
+        location /api {
+            proxy_pass http://localhost:8080;
+
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_buffering off;
+            proxy_redirect off;
+        }
+
+        root /var/www/abrechnung/;
+        index index.html;
+        location / {
+            try_files $uri /index.html =404;
+        }
+    }

--- a/charts/abrechnung/templates/deployment.yaml
+++ b/charts/abrechnung/templates/deployment.yaml
@@ -1,0 +1,111 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "abrechnung.fullname" . }}
+  labels:
+    {{- include "abrechnung.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "abrechnung.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "abrechnung.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "abrechnung.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}-frontend
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.frontendImage.repository }}:{{ .Values.frontendImage.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 3
+          env:
+            {{- include "abrechnung.env" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          - name: config
+            mountPath: "/etc/nginx/conf.d"
+            readOnly: true
+        - name: api
+          args: [api]
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          env:
+            {{- include "abrechnung.env" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+        - name: cron
+          args: [cron]
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- include "abrechnung.env" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "abrechnung.fullname" . }}-nginx-config
+          items:
+          - key: "nginx.conf"
+            path: "default.conf"
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/abrechnung/templates/hpa.yaml
+++ b/charts/abrechnung/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "abrechnung.fullname" . }}
+  labels:
+    {{- include "abrechnung.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "abrechnung.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/abrechnung/templates/ingress.yaml
+++ b/charts/abrechnung/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "abrechnung.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "abrechnung.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/abrechnung/templates/service.yaml
+++ b/charts/abrechnung/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "abrechnung.fullname" . }}
+  labels:
+    {{- include "abrechnung.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "abrechnung.selectorLabels" . | nindent 4 }}

--- a/charts/abrechnung/templates/serviceaccount.yaml
+++ b/charts/abrechnung/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "abrechnung.serviceAccountName" . }}
+  labels:
+    {{- include "abrechnung.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/abrechnung/templates/tests/test-connection.yaml
+++ b/charts/abrechnung/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "abrechnung.fullname" . }}-test-connection"
+  labels:
+    {{- include "abrechnung.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "abrechnung.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/abrechnung/values.yaml
+++ b/charts/abrechnung/values.yaml
@@ -1,0 +1,119 @@
+# Default values for abrechnung.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+# The values are mapped to: https://github.com/SFTtech/abrechnung/blob/master/.env.example
+
+postgresql:
+  host: "database"
+  user: abrechnung
+  name: abrechnung
+  # Set the name of an existing kubernetes secret that contains the database password
+  existingSecretName: ""
+  existingSecretKey: "password"
+
+abrechnung:
+  url: http://localhost:8080
+  name: abrechnung
+  pythonSecret:
+    # Set the name of an existing kubernetes secret that contains the secret value
+    existingSecretName: ""
+    existingSecretKey: "secret"
+  port: 8080
+  id: default
+  registration:
+    enabled: false
+    validEmailDomains: "sft.lol,sft.mx"
+    allowGuestUsers: true
+  email:
+    address: abrechnungs@sft.lol
+    host: mail
+    port: 1025
+    mode: smtp
+    username: abrechnung
+    password: abrechnung
+
+image:
+  repository: quay.io/abrechnung/api
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+frontendImage:
+  repository: quay.io/abrechnung/frontend
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  className: ""
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    kubernetes.io/ingress.class: "nginx"
+  hosts:
+    - host: abrechnung.lukasre.ch
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls:
+   - secretName: abrechnung-tls
+     hosts:
+       - abrechnung.lukasre.ch
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Hi everyone,

Found your project on the 37c3 page https://events.ccc.de/congress/2023/hub/en/project/abrechnung/. I wanted to set up the tool on my k8s cluster for my friends to use. I install most tools based on helm charts, and since there was no helm chart for this, I created one.

This PR should not be understood as ready to merge; I just wanted to open it to discuss whether this installation option should be added. I think it would be a great addition since Helm has become the de-facto standard in installing applications on k8s.

If yes, I would be happy to add the necessary documentation to my PR to get this merged.

I will also be at the 37c3, we can also discuss there.

Cheers,
Lukas