### PR TITLE
Honour group currency in new transactions

### DIFF
--- a/frontend/libs/redux/src/lib/transactions/transactionSlice.ts
+++ b/frontend/libs/redux/src/lib/transactions/transactionSlice.ts
@@ -275,10 +275,11 @@ export const createTransaction = createAsyncThunk<
             >
         >;
     },
-    { state: ITransactionRootState }
+    { state: IRootState }
 >("createPurchase", async ({ groupId, type, data }, { getState, dispatch }) => {
     const state = getState();
     const transactionId = state.transactions.nextLocalTransactionId;
+    const group = state.groups.groups.byId[groupId];
     const transactionBase = {
         id: transactionId,
         group_id: groupId,
@@ -286,7 +287,7 @@ export const createTransaction = createAsyncThunk<
         description: "",
         value: 0,
         currency_conversion_rate: 1.0,
-        currency_symbol: "€",
+        currency_symbol: group.currency_symbol,
         billed_at: toISODateString(new Date()),
         creditor_shares: {},
         debitor_shares: {},


### PR DESCRIPTION
Hi all, thanks for developing this! When creating new transactions via the web front end, the € symbol is always used, irrespective of the group's currency symbol. Instead of hardcoding the symbol, the `createTransaction` function should retrieve it from the state. To get access to the group data (including currency symbol), I had to change the state type from `ITransactionRootState` to `IRootState`, maybe not the most elegant but I couldn't think of anything better.