### PR TITLE
Dynamically change Nginx configuration

### DIFF
--- a/docker/Dockerfile-frontend
+++ b/docker/Dockerfile-frontend
@@ -3,3 +3,4 @@ FROM docker.io/nginx:stable-alpine
 COPY --chown=nginx:nginx frontend/dist/apps/web/ /var/www/abrechnung/
 COPY --chown=nginx:nginx frontend/apps/web/src/assets/config.json /var/www/abrechnung/config.json
 COPY docker/nginx-static /etc/nginx/conf.d/default.conf
+COPY docker/entrypoint-frontend.sh /docker-entrypoint.d/99-abrechnung.sh

--- a/docker/Dockerfile-frontend
+++ b/docker/Dockerfile-frontend
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 FROM docker.io/nginx:stable-alpine
-COPY --chown=nginx:nginx frontend/apps/web/ /var/www/abrechnung/
+COPY --chown=nginx:nginx frontend/dist/apps/web/ /var/www/abrechnung/
 COPY --chown=nginx:nginx frontend/apps/web/src/assets/config.json /var/www/abrechnung/config.json
 COPY docker/nginx-static /etc/nginx/conf.d/default.conf
 COPY --chmod=0755 docker/entrypoint-frontend.sh /docker-entrypoint.d/99-abrechnung.sh

--- a/docker/Dockerfile-frontend
+++ b/docker/Dockerfile-frontend
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 FROM docker.io/nginx:stable-alpine
-COPY --chown=nginx:nginx frontend/dist/apps/web/ /var/www/abrechnung/
+COPY --chown=nginx:nginx frontend/apps/web/ /var/www/abrechnung/
 COPY --chown=nginx:nginx frontend/apps/web/src/assets/config.json /var/www/abrechnung/config.json
 COPY docker/nginx-static /etc/nginx/conf.d/default.conf
 COPY --chown=nginx:nginx --chmod=0750 docker/entrypoint-frontend.sh /docker-entrypoint.d/99-abrechnung.sh

--- a/docker/Dockerfile-frontend
+++ b/docker/Dockerfile-frontend
@@ -3,4 +3,4 @@ FROM docker.io/nginx:stable-alpine
 COPY --chown=nginx:nginx frontend/apps/web/ /var/www/abrechnung/
 COPY --chown=nginx:nginx frontend/apps/web/src/assets/config.json /var/www/abrechnung/config.json
 COPY docker/nginx-static /etc/nginx/conf.d/default.conf
-COPY --chown=nginx:nginx --chmod=0750 docker/entrypoint-frontend.sh /docker-entrypoint.d/99-abrechnung.sh
+COPY --chmod=0755 docker/entrypoint-frontend.sh /docker-entrypoint.d/99-abrechnung.sh

--- a/docker/Dockerfile-frontend
+++ b/docker/Dockerfile-frontend
@@ -3,4 +3,4 @@ FROM docker.io/nginx:stable-alpine
 COPY --chown=nginx:nginx frontend/dist/apps/web/ /var/www/abrechnung/
 COPY --chown=nginx:nginx frontend/apps/web/src/assets/config.json /var/www/abrechnung/config.json
 COPY docker/nginx-static /etc/nginx/conf.d/default.conf
-COPY docker/entrypoint-frontend.sh /docker-entrypoint.d/99-abrechnung.sh
+COPY --chown=nginx:nginx --chmod=0750 docker/entrypoint-frontend.sh /docker-entrypoint.d/99-abrechnung.sh

--- a/docker/entrypoint-frontend.sh
+++ b/docker/entrypoint-frontend.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+CONF="/etc/nginx/conf.d/default.conf"
+
+[[ ! -z "${ABRECHNUNG_API__HOST}" ]] && sed -i "s/api:/${ABRECHNUNG_API__HOST}:/g" "$CONF"
+[[ ! -z "${ABRECHNUNG_API__PORT}" ]] && sed -i "s/:8080/:${ABRECHNUNG_API__PORT}/g" "$CONF"

--- a/docker/entrypoint-frontend.sh
+++ b/docker/entrypoint-frontend.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 CONF="/etc/nginx/conf.d/default.conf"
 

--- a/docker/entrypoint-frontend.sh
+++ b/docker/entrypoint-frontend.sh
@@ -4,3 +4,4 @@ CONF="/etc/nginx/conf.d/default.conf"
 
 [[ ! -z "${ABRECHNUNG_API__HOST}" ]] && sed -i "s/api:/${ABRECHNUNG_API__HOST}:/g" "$CONF"
 [[ ! -z "${ABRECHNUNG_API__PORT}" ]] && sed -i "s/:8080/:${ABRECHNUNG_API__PORT}/g" "$CONF"
+[[ ! -f "/proc/net/if_inet6" ]] && sed -i "s/listen \[::\]/#listen \[::\]/g" "$CONF"


### PR DESCRIPTION
Script for the frontend container that is automatically executed by Nginx's entrypoint in order to change `/etc/nginx/conf.d/default.conf` configurations to:

- Optionally set the API container name via `ABRECHNUNG_API__HOST` environment variable;
- Optionally set the API container port via `ABRECHNUNG_API__PORT` environment variable;
- Disable listening on IPv6 port 80 if the host doesn't support that protocol, fixing the error `[emerg] socket() [::]:80 failed (97: Address family not supported by protocol)`.