### PR TITLE
Docker entrypoint-frontend.sh bugfixes and optimizations

### DIFF
--- a/docker/entrypoint-frontend.sh
+++ b/docker/entrypoint-frontend.sh
@@ -2,6 +2,6 @@
 
 CONF="/etc/nginx/conf.d/default.conf"
 
-[ -n "${ABRECHNUNG_API__HOST}" ] && sed -i "s/api:/${ABRECHNUNG_API__HOST}:/g" "$CONF"
-[ -n "${ABRECHNUNG_API__PORT}" ] && sed -i "s/:8080/:${ABRECHNUNG_API__PORT}/g" "$CONF"
-[ ! -f "/proc/net/if_inet6" ] && sed -i "s/listen \[::\]/#listen \[::\]/g" "$CONF"
+[ -n "${ABRECHNUNG_API__HOST}" ] && sed -i "s/ api:/ ${ABRECHNUNG_API__HOST}:/g" "$CONF"
+[ -n "${ABRECHNUNG_API__PORT}" ] && sed -i "s/:8080;/:${ABRECHNUNG_API__PORT};/g" "$CONF"
+[ ! -f "/proc/net/if_inet6" ] && sed -i "s/ listen \[::\]/ #listen \[::\]/g" "$CONF"

--- a/docker/entrypoint-frontend.sh
+++ b/docker/entrypoint-frontend.sh
@@ -2,6 +2,6 @@
 
 CONF="/etc/nginx/conf.d/default.conf"
 
-[[ ! -z "${ABRECHNUNG_API__HOST}" ]] && sed -i "s/api:/${ABRECHNUNG_API__HOST}:/g" "$CONF"
-[[ ! -z "${ABRECHNUNG_API__PORT}" ]] && sed -i "s/:8080/:${ABRECHNUNG_API__PORT}/g" "$CONF"
-[[ ! -f "/proc/net/if_inet6" ]] && sed -i "s/listen \[::\]/#listen \[::\]/g" "$CONF"
+[ ! -z "${ABRECHNUNG_API__HOST}" ] && sed -i "s/api:/${ABRECHNUNG_API__HOST}:/g" "$CONF"
+[ ! -z "${ABRECHNUNG_API__PORT}" ] && sed -i "s/:8080/:${ABRECHNUNG_API__PORT}/g" "$CONF"
+[ ! -f "/proc/net/if_inet6" ] && sed -i "s/listen \[::\]/#listen \[::\]/g" "$CONF"

--- a/docker/entrypoint-frontend.sh
+++ b/docker/entrypoint-frontend.sh
@@ -2,6 +2,6 @@
 
 CONF="/etc/nginx/conf.d/default.conf"
 
-[ ! -z "${ABRECHNUNG_API__HOST}" ] && sed -i "s/api:/${ABRECHNUNG_API__HOST}:/g" "$CONF"
-[ ! -z "${ABRECHNUNG_API__PORT}" ] && sed -i "s/:8080/:${ABRECHNUNG_API__PORT}/g" "$CONF"
+[ -n "${ABRECHNUNG_API__HOST}" ] && sed -i "s/api:/${ABRECHNUNG_API__HOST}:/g" "$CONF"
+[ -n "${ABRECHNUNG_API__PORT}" ] && sed -i "s/:8080/:${ABRECHNUNG_API__PORT}/g" "$CONF"
 [ ! -f "/proc/net/if_inet6" ] && sed -i "s/listen \[::\]/#listen \[::\]/g" "$CONF"


### PR DESCRIPTION
Fixed bug where sed would replace substring matches on every container restart, e.g: 

**1st container start:** `server abrechnung-api:8080`
**2nd container start:** `server abrechnung-abrechnung-api:8080`
**3rd container start:** `server abrechnung-abrechnung-abrechnung-api:8080`