### PR TITLE
Ensure two decimal places for currency values

### DIFF
--- a/frontend/apps/web/src/components/NumericInput.tsx
+++ b/frontend/apps/web/src/components/NumericInput.tsx
@@ -6,14 +6,15 @@ import { parseAbrechnungFloat } from "@abrechnung/utils";
 export type NumericInputProps = {
     onChange: (value: number) => void;
     value?: number | undefined;
+    isCurrency?: boolean | false;
 } & Omit<TextFieldProps, "value" | "onChange" | "onBlur" | "onKeyUp">;
 
-export const NumericInput: React.FC<NumericInputProps> = ({ value, onChange, ...props }) => {
+export const NumericInput: React.FC<NumericInputProps> = ({ value, isCurrency, onChange, ...props }) => {
     const [internalValue, setInternalValue] = React.useState("");
 
     React.useEffect(() => {
-        setInternalValue(String(value));
-    }, [value, setInternalValue]);
+        setInternalValue(isCurrency ? value.toFixed(2) : String(value));
+    }, [value, setInternalValue, isCurrency]);
 
     const onInternalChange = (event) => {
         setInternalValue(event.target.value);
@@ -23,7 +24,7 @@ export const NumericInput: React.FC<NumericInputProps> = ({ value, onChange, ...
     const propagateChange = () => {
         const parsedValue = parseAbrechnungFloat(internalValue);
         if (!isNaN(parsedValue)) {
-            setInternalValue(String(parsedValue));
+            setInternalValue(isCurrency ? value.toFixed(2) : String(value));
             onChange(parsedValue);
         }
     };

--- a/frontend/apps/web/src/components/NumericInput.tsx
+++ b/frontend/apps/web/src/components/NumericInput.tsx
@@ -24,7 +24,7 @@ export const NumericInput: React.FC<NumericInputProps> = ({ value, isCurrency, o
     const propagateChange = () => {
         const parsedValue = parseAbrechnungFloat(internalValue);
         if (!isNaN(parsedValue)) {
-            setInternalValue(isCurrency ? value.toFixed(2) : String(value));
+            setInternalValue(isCurrency ? parsedValue.toFixed(2) : String(parsedValue));
             onChange(parsedValue);
         }
     };

--- a/frontend/apps/web/src/pages/transactions/TransactionDetail/TransactionMetadata.tsx
+++ b/frontend/apps/web/src/pages/transactions/TransactionDetail/TransactionMetadata.tsx
@@ -149,6 +149,7 @@ export const TransactionMetadata: React.FC<Props> = ({
                     helperText={validationErrors.fieldErrors.value}
                     onChange={(value) => pushChanges({ value })}
                     value={transaction.value}
+                    isCurrency={true}
                     disabled={!transaction.is_wip}
                     InputProps={{
                         endAdornment: <InputAdornment position="end">{transaction.currency_symbol}</InputAdornment>,

--- a/frontend/apps/web/src/pages/transactions/TransactionDetail/purchase/TransactionPositions.tsx
+++ b/frontend/apps/web/src/pages/transactions/TransactionDetail/purchase/TransactionPositions.tsx
@@ -104,6 +104,7 @@ const PositionTableRow: React.FC<PositionTableRowProps> = ({
             <TableCell align="right">
                 <NumericInput
                     value={position.price}
+                    isCurrency={true}
                     style={{ width: 70 }}
                     error={validationError && !!validationError.fieldErrors.price}
                     helperText={validationError && validationError.fieldErrors.price}


### PR DESCRIPTION
Currently when entering prices like "81,10" or "45,50" (values ending with a zero), the trailing zero is omitted in the display:
<img width="603" alt="Screenshot 2024-05-09 at 21 00 29" src="https://github.com/SFTtech/abrechnung/assets/14217185/b4d5fa14-1318-4d61-8628-c7a3ebf170bb">

This PR corrects the behavior. Disclaimer: I have never worked with React before, so there is probably a better way to do this. I will happily take pointers.
