### PR TITLE
fix: use decimal input for numeric input fields

### DIFF
--- a/frontend/apps/web/src/components/NumericInput.tsx
+++ b/frontend/apps/web/src/components/NumericInput.tsx
@@ -46,7 +46,7 @@ export const NumericInput: React.FC<NumericInputProps> = ({ value, isCurrency, o
             onBlur={onInternalBlur}
             onKeyUp={onKeyUp}
             variant="standard"
-            inputProps={{ inputMode: "numeric" }}
+            inputProps={{ inputMode: "decimal" }}
             {...props}
         />
     );


### PR DESCRIPTION
otherwise the decimal separator button won't show up on mobile.