### PR TITLE
Skip psql extensions

### DIFF
--- a/abrechnung/cli/database.py
+++ b/abrechnung/cli/database.py
@@ -1,4 +1,4 @@
-gimport asyncio
+import asyncio
 from typing import Annotated, Optional
 
 import typer


### PR DESCRIPTION
  ## Summary

  Add a skiplist to prevent dropping PostgreSQL extension functions during database migrations.

 ## Problem

  When running database migrations or reloading database code, the migration system would attempt to drop and recreate all functions in the schema. This includes functions like set_user and reset_user that are created by PostgreSQL extensions (e.g., the set_user extension) rather than by our application.

  Dropping these extension-managed functions causes errors because:
  1. The functions are owned by the extension, not the application
  2. The migration system cannot recreate them since their definitions aren't in our codebase

 ## Solution

  Introduce an EXTENSION_FUNCTION_SKIPLIST that explicitly lists functions that should be excluded from the drop/recreate cycle during:
  - migrate command
  - rebuild command
  - reload_code command

  The skiplist currently includes:
  - set_user - from the set_user PostgreSQL extension
  - reset_user - from the set_user PostgreSQL extension