### PR TITLE
Ensure the Dockerfile is compatible with manual developing setup

### DIFF
--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -7,6 +7,7 @@ RUN /opt/abrechnung-venv/bin/python3 -m pip install /src
 
 FROM python:3.12-alpine
 RUN addgroup -S abrechnung && adduser -S abrechnung -G abrechnung && apk add --no-cache curl
+RUN mkdir -p /etc/abrechnung && chown abrechnung:abrechnung /etc/abrechnung
 COPY --from=builder /opt/abrechnung-venv/ /opt/abrechnung-venv/
 ADD --chmod=644 --chown=abrechnung:abrechnung docker/abrechnung.yaml /etc/abrechnung/abrechnung.yaml
 ADD --chmod=755 ./docker/entrypoint.py /

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -3,7 +3,7 @@
 ## As Users
 
 In case you encounter bugs or have ideas for new and useful features don't hesitate to open an
-[issue](https://github.com/SFTtech/abrechnung/issues>) and start a discussion.
+[issue](https://github.com/SFTtech/abrechnung/issues) and start a discussion.
 
 ## As Developers
 


### PR DESCRIPTION
As I prefer to build the Dockerfile manually, I found that the Dockerfile itself does not set the permissions for the `/etc/abrechnung` folder.

So, I simply added the explicit `creation` and `chmod` of the folder.