### PR TITLE
refactor(web): remove the need for redirect-guards in account / transaction details

### DIFF
--- a/apps/web/src/pages/accounts/AccountDetail/AccountDetail.tsx
+++ b/apps/web/src/pages/accounts/AccountDetail/AccountDetail.tsx
@@ -2,8 +2,7 @@ import { AccountTransactionList } from "@/pages/accounts/AccountDetail/AccountTr
 import { BalanceHistoryGraph } from "@/pages/accounts/AccountDetail/BalanceHistoryGraph";
 import { ClearingAccountDetail } from "@/pages/accounts/AccountDetail/ClearingAccountDetail";
 import { MobilePaper } from "@/components/style";
-import { Loading } from "@abrechnung/components";
-import { useQuery, useTitle } from "@/core/utils";
+import { useTitle } from "@/core/utils";
 import { Grid, Typography } from "@mui/material";
 import * as React from "react";
 import { Navigate, useParams } from "react-router";
@@ -35,7 +34,6 @@ export const AccountDetail: React.FC<Props> = ({ groupId }) => {
 
     const group = useGroup(groupId);
     const account = useAccount(groupId, accountId);
-    const query = useQuery();
 
     useTitle(
         t(account?.type === "clearing" ? "accounts.detail.tabTitleEvent" : "accounts.detail.tabTitleAccount", "", {
@@ -45,11 +43,7 @@ export const AccountDetail: React.FC<Props> = ({ groupId }) => {
     );
 
     if (account === undefined) {
-        if (query.get("no-redirect") === "true") {
-            return <Loading />;
-        } else {
-            return <Navigate to="/404" />;
-        }
+        return <Navigate to={`/groups/${groupId}/accounts`} />;
     }
 
     if (account.is_wip) {

--- a/apps/web/src/pages/accounts/AccountDetail/AccountInfo.tsx
+++ b/apps/web/src/pages/accounts/AccountDetail/AccountInfo.tsx
@@ -90,7 +90,7 @@ export const AccountInfo: React.FC<Props> = ({ groupId, account }) => {
                     // we saved a purely local account, i.e. we created a new account -> navigate to account list
                     navigate(getAccountListLink(groupId, "personal"));
                 } else if (oldAccountId !== newAccount.id) {
-                    navigate(getAccountLink(groupId, newAccount.type, newAccount.id) + "?no-redirect=true", {
+                    navigate(getAccountLink(groupId, newAccount.type, newAccount.id), {
                         replace: true,
                     });
                 }

--- a/apps/web/src/pages/accounts/AccountDetail/AccountTransactionList.tsx
+++ b/apps/web/src/pages/accounts/AccountDetail/AccountTransactionList.tsx
@@ -55,7 +55,7 @@ export const AccountTransactionList: React.FC<Props> = ({ groupId, account }) =>
         )
             .unwrap()
             .then(({ transaction }) => {
-                navigate(`/groups/${groupId}/transactions/${transaction.id}?no-redirect=true`);
+                navigate(`/groups/${groupId}/transactions/${transaction.id}`);
             })
             .catch(() => toast.error("Creating a transaction failed"));
     };

--- a/apps/web/src/pages/accounts/ClearingAccountList/ClearingAccountList.tsx
+++ b/apps/web/src/pages/accounts/ClearingAccountList/ClearingAccountList.tsx
@@ -84,7 +84,7 @@ export const ClearingAccountList: React.FC<Props> = ({ groupId }) => {
         dispatch(createAccount({ groupId, type: "clearing" }))
             .unwrap()
             .then(({ account }) => {
-                navigate(getAccountLink(groupId, account.type, account.id) + "?no-redirect=true");
+                navigate(getAccountLink(groupId, account.type, account.id));
             });
     };
 

--- a/apps/web/src/pages/accounts/PersonalAccountList/PersonalAccountList.tsx
+++ b/apps/web/src/pages/accounts/PersonalAccountList/PersonalAccountList.tsx
@@ -78,7 +78,7 @@ export const PersonalAccountList: React.FC<Props> = ({ groupId }) => {
         dispatch(createAccount({ groupId, type: "personal" }))
             .unwrap()
             .then(({ account }) => {
-                navigate(`/groups/${groupId}/accounts/${account.id}?no-redirect=true`);
+                navigate(`/groups/${groupId}/accounts/${account.id}`);
             })
             .catch((err) => {
                 toast.error(`Error while creating account: ${err}`);

--- a/apps/web/src/pages/accounts/SettlementPlanDisplay.tsx
+++ b/apps/web/src/pages/accounts/SettlementPlanDisplay.tsx
@@ -45,7 +45,7 @@ export const SettlementPlanDisplay: React.FC<Props> = ({ groupId }) => {
         )
             .unwrap()
             .then(({ transaction }) => {
-                navigate(`/groups/${groupId}/transactions/${transaction.id}?no-redirect=true`);
+                navigate(`/groups/${groupId}/transactions/${transaction.id}`);
             });
     };
 

--- a/apps/web/src/pages/groups/Group.tsx
+++ b/apps/web/src/pages/groups/Group.tsx
@@ -2,6 +2,8 @@ import {
     fetchGroupDependencies,
     selectGroupAccountsStatus,
     selectGroupTransactionsStatus,
+    setAccountStatus,
+    setTransactionStatus,
     useGroup,
 } from "@abrechnung/redux";
 import React, { Suspense } from "react";

--- a/apps/web/src/pages/transactions/TransactionDetail/TransactionDetail.tsx
+++ b/apps/web/src/pages/transactions/TransactionDetail/TransactionDetail.tsx
@@ -1,7 +1,6 @@
 import { MobilePaper } from "@/components/style";
-import { Loading } from "@abrechnung/components";
 import { api } from "@/core/api";
-import { useQuery, useTitle } from "@/core/utils";
+import { useTitle } from "@/core/utils";
 import { useAppDispatch, useAppSelector } from "@/store";
 import {
     deleteTransaction,
@@ -38,7 +37,6 @@ export const TransactionDetail: React.FC<Props> = ({ groupId }) => {
     const { t } = useTranslation();
     const params = useParams();
     const dispatch = useAppDispatch();
-    const query = useQuery();
     const navigate = useNavigate();
     const transactionId = Number(params["id"]);
 
@@ -136,7 +134,7 @@ export const TransactionDetail: React.FC<Props> = ({ groupId }) => {
             .then(({ oldTransactionId, transaction }) => {
                 setShowProgress(false);
                 if (oldTransactionId !== transaction.id) {
-                    navigate(`/groups/${groupId}/transactions/${transaction.id}?no-redirect=true`, { replace: true });
+                    navigate(`/groups/${groupId}/transactions/${transaction.id}`, { replace: true });
                 }
             })
             .catch((err) => {
@@ -146,11 +144,7 @@ export const TransactionDetail: React.FC<Props> = ({ groupId }) => {
     }, [transaction, setPositionValidationErrors, dispatch, setShowProgress, navigate, groupId, transactionId]);
 
     if (transaction === undefined) {
-        if (query.get("no-redirect") === "true") {
-            return <Loading />;
-        } else {
-            return <Navigate to="/404" />;
-        }
+        return <Navigate to={`/groups/${groupId}`} />;
     }
 
     return (

--- a/apps/web/src/pages/transactions/TransactionList/TransactionList.tsx
+++ b/apps/web/src/pages/transactions/TransactionList/TransactionList.tsx
@@ -221,14 +221,14 @@ export const TransactionList: React.FC<Props> = ({ groupId }) => {
         dispatch(createTransaction({ groupId, type: "purchase" }))
             .unwrap()
             .then(({ transaction }) => {
-                navigate(`/groups/${groupId}/transactions/${transaction.id}?no-redirect=true`);
+                navigate(`/groups/${groupId}/transactions/${transaction.id}`);
             });
     };
     const onCreateTransfer = () => {
         dispatch(createTransaction({ groupId, type: "transfer" }))
             .unwrap()
             .then(({ transaction }) => {
-                navigate(`/groups/${groupId}/transactions/${transaction.id}?no-redirect=true`);
+                navigate(`/groups/${groupId}/transactions/${transaction.id}`);
             });
     };
 

--- a/libs/redux/src/lib/accounts/accountSlice.ts
+++ b/libs/redux/src/lib/accounts/accountSlice.ts
@@ -407,14 +407,19 @@ const accountSlice = createSlice({
             const s = getGroupScopedState<AccountState, AccountSliceState>(state, groupId);
             removeEntity(s.wipAccounts, accountId);
         },
+        setAccountStatus: (state, action: PayloadAction<{ groupId: number; status: StateStatus }>) => {
+            const { groupId, status } = action.payload;
+            initializeGroupState(state, groupId);
+            const s = getGroupScopedState<AccountState, AccountSliceState>(state, groupId);
+            if (s) {
+                s.status = status;
+            }
+        },
     },
     extraReducers: (builder) => {
         builder.addCase(fetchAccounts.pending, (state, action) => {
             const groupId = action.meta.arg.groupId;
-            if (!state.byGroupId[groupId]) {
-                // TODO: add separate base action to do this
-                initializeGroupState(state, groupId);
-            }
+            initializeGroupState(state, groupId);
         });
         builder.addCase(fetchAccounts.rejected, (state, action) => {
             const s = getGroupScopedState<AccountState, AccountSliceState>(state, action.meta.arg.groupId);
@@ -423,10 +428,6 @@ const accountSlice = createSlice({
         builder.addCase(fetchAccounts.fulfilled, (state, action) => {
             const accounts = action.payload;
             const groupId = action.meta.arg.groupId;
-            if (!state.byGroupId[groupId]) {
-                // TODO: add separate base action to do this
-                initializeGroupState(state, groupId);
-            }
             const s = getGroupScopedState<AccountState, AccountSliceState>(state, groupId);
             // TODO: optimize such that we maybe only update those who have actually changed??
             const byId = accounts.reduce<{ [k: number]: Account }>((byId, account) => {
@@ -475,7 +476,13 @@ const accountSlice = createSlice({
 // local reducers
 const { advanceNextLocalAccountId } = accountSlice.actions;
 
-export const { wipAccountUpdated, accountAdded, accountEditStarted, copyAccount, discardAccountChange } =
-    accountSlice.actions;
+export const {
+    wipAccountUpdated,
+    accountAdded,
+    accountEditStarted,
+    copyAccount,
+    discardAccountChange,
+    setAccountStatus,
+} = accountSlice.actions;
 
 export const { reducer: accountReducer } = accountSlice;

--- a/libs/redux/src/lib/thunks.ts
+++ b/libs/redux/src/lib/thunks.ts
@@ -1,7 +1,7 @@
 import { PURGE } from "redux-persist";
 import { Api } from "@abrechnung/api";
-import { fetchAccounts } from "./accounts";
-import { fetchTransactions } from "./transactions";
+import { fetchAccounts, setAccountStatus } from "./accounts";
+import { fetchTransactions, setTransactionStatus } from "./transactions";
 import { IRootState } from "./types";
 import { createAsyncThunkWithErrorHandling } from "./utils";
 
@@ -12,6 +12,8 @@ export const fetchGroupDependencies = createAsyncThunkWithErrorHandling<
 >(
     "fetchGroupDependencies",
     async ({ groupId, api, fetchAnyway = false }, { dispatch }) => {
+        dispatch(setTransactionStatus({ groupId, status: "loading" }));
+        dispatch(setAccountStatus({ groupId, status: "loading" }));
         await Promise.all([
             dispatch(fetchAccounts({ groupId, api, fetchAnyway })).unwrap(),
             dispatch(fetchTransactions({ groupId, api, fetchAnyway })).unwrap(),

--- a/libs/redux/src/lib/transactions/transactionSlice.ts
+++ b/libs/redux/src/lib/transactions/transactionSlice.ts
@@ -708,14 +708,19 @@ const transactionSlice = createSlice({
             removeEntity(s.wipTransactions, transactionId);
             delete s.wipTransactions.balanceEffects[transactionId];
         },
+        setTransactionStatus: (state, action: PayloadAction<{ groupId: number; status: StateStatus }>) => {
+            const { groupId, status } = action.payload;
+            initializeGroupState(state, groupId);
+            const s = getGroupScopedState<TransactionState, TransactionSliceState>(state, groupId);
+            if (s) {
+                s.status = status;
+            }
+        },
     },
     extraReducers: (builder) => {
         builder.addCase(fetchTransactions.pending, (state, action) => {
             const groupId = action.meta.arg.groupId;
-            if (!state.byGroupId[groupId]) {
-                // TODO: add separate base action to do this
-                initializeGroupState(state, groupId);
-            }
+            initializeGroupState(state, groupId);
         });
         builder.addCase(fetchTransactions.rejected, (state, action) => {
             const s = getGroupScopedState<TransactionState, TransactionSliceState>(state, action.meta.arg.groupId);
@@ -795,6 +800,7 @@ export const {
     wipPositionAdded,
     positionDeleted,
     discardTransactionChange,
+    setTransactionStatus,
 } = transactionSlice.actions;
 
 export const { reducer: transactionReducer } = transactionSlice;


### PR DESCRIPTION
Now blocks while loading group contents in order for fresh page loads to have the most recent data. This fixes the issue of loading links to currently uncached transactions / accounts leading to 404 redirects.

closes #348